### PR TITLE
chore: apply cargo fmt

### DIFF
--- a/src/gc.rs
+++ b/src/gc.rs
@@ -11,8 +11,8 @@ use crate::{
 use crate::MerkleNode;
 
 //use asterix to avoid unresolved import https://github.com/rust-analyzer/rust-analyzer/issues/7459#issuecomment-907714513
-use derivative::*;
 use dashmap::{mapref::entry::Entry, DashMap};
+use derivative::*;
 use log::*;
 use primitive_types::H256;
 use rlp::Rlp;

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -50,6 +50,4 @@ pub mod tests {
             Self(Vec::arbitrary(&mut Gen::new(AVG_DATA_SIZE)))
         }
     }
-
-    
 }


### PR DESCRIPTION
triedb 1 % cargo --version
cargo 1.53.0 (4369396ce 2021-04-27)

Applying default settings of rustfmt