### PR TITLE
chore(merkle_node): Refactor merkle node type.

### DIFF
--- a/src/merkle/mod.rs
+++ b/src/merkle/mod.rs
@@ -3,4 +3,4 @@
 pub mod nibble;
 mod node;
 
-pub use node::{empty_nodes, MerkleNode, MerkleValue};
+pub use node::{empty_nodes, Branch, Extension, Leaf, MerkleNode, MerkleValue};

--- a/src/ops/build.rs
+++ b/src/ops/build.rs
@@ -33,7 +33,7 @@ pub fn build_node<'a>(map: &HashMap<NibbleVec, &'a [u8]>) -> (MerkleNode<'a>, Ch
     assert!(!map.is_empty());
     if map.len() == 1 {
         let key = map.keys().next().unwrap();
-        return (MerkleNode::Leaf(key.clone(), map.get(key).unwrap()), change);
+        return (MerkleNode::leaf(key.clone(), map.get(key).unwrap()), change);
     }
 
     debug_assert!(map.len() > 1);
@@ -49,7 +49,7 @@ pub fn build_node<'a>(map: &HashMap<NibbleVec, &'a [u8]>) -> (MerkleNode<'a>, Ch
         let (value, subchange) = build_value(node);
         change.merge(&subchange);
 
-        (MerkleNode::Extension(common.into(), value), change)
+        (MerkleNode::extension(common.into(), value), change)
     } else {
         let mut nodes: [MerkleValue<'_>; 16] = empty_nodes();
 
@@ -78,6 +78,6 @@ pub fn build_node<'a>(map: &HashMap<NibbleVec, &'a [u8]>) -> (MerkleNode<'a>, Ch
             .find(|&(key, _value)| key.is_empty())
             .map(|(_key, value)| *value);
 
-        (MerkleNode::Branch(nodes, additional), change)
+        (MerkleNode::branch(nodes, additional), change)
     }
 }

--- a/src/ops/get.rs
+++ b/src/ops/get.rs
@@ -1,7 +1,7 @@
 use rlp::{self, Rlp};
 
 use crate::{
-    merkle::{nibble::NibbleVec, MerkleNode, MerkleValue},
+    merkle::{nibble::NibbleVec, Branch, Extension, Leaf, MerkleNode, MerkleValue},
     Database,
 };
 
@@ -27,21 +27,30 @@ pub fn get_by_node<'a, D: Database>(
     database: &'a D,
 ) -> Option<&'a [u8]> {
     match node {
-        MerkleNode::Leaf(node_nibble, node_value) => {
+        MerkleNode::Leaf(Leaf {
+            nibbles: node_nibble,
+            data: node_value,
+        }) => {
             if node_nibble == nibble {
                 Some(node_value)
             } else {
                 None
             }
         }
-        MerkleNode::Extension(node_nibble, node_value) => {
+        MerkleNode::Extension(Extension {
+            nibbles: node_nibble,
+            value: node_value,
+        }) => {
             if nibble.starts_with(&node_nibble) {
                 get_by_value(node_value, nibble[node_nibble.len()..].into(), database)
             } else {
                 None
             }
         }
-        MerkleNode::Branch(node_nodes, node_additional) => {
+        MerkleNode::Branch(Branch {
+            childs: node_nodes,
+            data: node_additional,
+        }) => {
             if nibble.is_empty() {
                 node_additional
             } else {

--- a/src/walker/mod.rs
+++ b/src/walker/mod.rs
@@ -1,7 +1,7 @@
 use std::borrow::Borrow;
 
 use crate::{
-    merkle::{nibble::Entry, MerkleNode, MerkleValue},
+    merkle::{nibble::Entry, Branch, Extension, Leaf, MerkleNode, MerkleValue},
     Database,
 };
 use primitive_types::H256;
@@ -66,16 +66,19 @@ where
     // fn process_node(&self, mut nibble: NibbleVec, node: &MerkleNode) -> Result<()> {
     fn process_node(&self, mut entry: Entry<&MerkleNode>) -> Result<()> {
         match entry.value {
-            MerkleNode::Leaf(nibbles, data) => {
+            MerkleNode::Leaf(Leaf { nibbles, data }) => {
                 entry.nibble.extend_from_slice(nibbles);
                 let key = crate::merkle::nibble::into_key(&entry.nibble);
                 self.data_inspector.inspect_data_raw(key, data)
             }
-            MerkleNode::Extension(nibbles, value) => {
+            MerkleNode::Extension(Extension { nibbles, value }) => {
                 entry.nibble.extend_from_slice(nibbles);
                 self.process_value(Entry::new(entry.nibble, value))
             }
-            MerkleNode::Branch(values, maybe_data) => {
+            MerkleNode::Branch(Branch {
+                childs: values,
+                data: maybe_data,
+            }) => {
                 // lack of copy on result, forces setting array manually
                 let mut values_result = [
                     None, None, None, None, None, None, None, None, None, None, None, None, None,


### PR DESCRIPTION
Move Branch/Extension/Leaf variant to it's own type, this slightly reduce match readability, but instead allows split branch proccessing to its own function, with better readability.