### PR TITLE
[wip] chore(fuzz, test): simplify fuzz, 1fuzz, 6 quickcheck test scenarios

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,14 +26,14 @@ tracing-attributes = {version = "0.1.11", optional = true}
 tracing = {version = "0.1.35", optional = true}
 termtree = "0.4.0"
 etcommon-hexutil = "0.2.4"
+bincode = "1.3.1"
+serde = { version = "1.0.123", features = ["derive"] }
 
 [dev-dependencies]
-bincode = "1.3.1"
 criterion = { version = "0.4.0", features = ["html_reports"]}
 quickcheck = "1.0.3"
 quickcheck_macros = "1.0.0"
 rand = "0.8.5"
-serde = { version = "1.0.123", features = ["derive"] }
 serde_json = "1.0.89"
 tempfile = "3.2.0"
 hex-literal="0.3"

--- a/benches/bench_diff.rs
+++ b/benches/bench_diff.rs
@@ -6,11 +6,7 @@ use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use primitive_types::H256;
 use rand::seq::index::sample;
 
-use triedb::{
-    diff, empty_trie_hash,
-    gc::{testing::MapWithCounterCached, TrieCollection},
-    TrieMut,
-};
+use triedb::{debug::MapWithCounterCached, diff, empty_trie_hash, gc::TrieCollection, TrieMut};
 
 pub fn no_childs(_: &[u8]) -> Vec<H256> {
     vec![]

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -891,6 +891,7 @@ name = "triedb"
 version = "0.5.0"
 dependencies = [
  "anyhow",
+ "bincode",
  "dashmap",
  "derivative",
  "etcommon-hexutil",
@@ -899,6 +900,7 @@ dependencies = [
  "rayon",
  "rlp",
  "rocksdb",
+ "serde",
  "sha3",
  "termtree",
  "thiserror",
@@ -912,6 +914,7 @@ dependencies = [
  "env_logger",
  "etcommon-hexutil",
  "libfuzzer-sys",
+ "log",
  "primitive-types",
  "rocksdb",
  "serde",

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -16,6 +16,7 @@ rocksdb = { package = "rocksdb", git = "https://github.com/velas/rust-rocksdb", 
 etcommon-hexutil = "0.2.4"
 primitive-types = { version = "0.11.0", features = ["rlp", "serde"] }
 env_logger = "0.9"
+log="0.4"
 
 tempfile = "3.2.0"
 

--- a/fuzz/fuzz_targets/gc-multi-thread.rs
+++ b/fuzz/fuzz_targets/gc-multi-thread.rs
@@ -8,8 +8,7 @@ pub struct Key(pub [u8; 4]);
 #[derive(Copy, Clone, Eq, Hash, PartialEq, Debug)]
 pub struct FixedData(pub [u8; 32]);
 
-use primitive_types::H256;
-use serde::{Deserialize, Serialize};
+use triedb::debug::child_extractor::DataWithRoot;
 use std::collections::HashMap;
 use tempfile::tempdir;
 use triedb::empty_trie_hash;
@@ -129,27 +128,6 @@ impl<'a> Arbitrary<'a> for MyArgs {
 
 fuzz_target!(|arg: MyArgs| { qc_handles_inner_roots(arg.changes, arg.changes2) });
 
-#[derive(Eq, PartialEq, Debug, Clone, Copy, Serialize, Deserialize)]
-pub struct DataWithRoot {
-    pub root: H256,
-}
-
-impl DataWithRoot {
-    fn get_childs(data: &[u8]) -> Vec<H256> {
-        bincode::deserialize::<Self>(data)
-            .ok()
-            .into_iter()
-            .map(|e| e.root)
-            .collect()
-    }
-}
-impl Default for DataWithRoot {
-    fn default() -> Self {
-        Self {
-            root: empty_trie_hash!(),
-        }
-    }
-}
 
 fn routine(db: std::sync::Arc<DB>, changes: Vec<(Key, Vec<(Key, FixedData)>)>) {
     let cf = db.cf_handle("counter").unwrap();

--- a/src/ops/debug/child_extractor.rs
+++ b/src/ops/debug/child_extractor.rs
@@ -1,0 +1,60 @@
+use primitive_types::H256;
+use serde::{Deserialize, Serialize};
+
+use crate::gc::{RootGuard, TrieCollection};
+use crate::TrieMut;
+
+use super::MapWithCounterCached;
+
+#[derive(Eq, PartialEq, Debug, Clone, Copy, Serialize, Deserialize)]
+pub struct DataWithRoot {
+    pub root: H256,
+}
+
+impl DataWithRoot {
+    pub fn get_childs(data: &[u8]) -> Vec<H256> {
+        bincode::deserialize::<Self>(data)
+            .ok()
+            .into_iter()
+            .map(|e| e.root)
+            .collect()
+    }
+}
+impl Default for DataWithRoot {
+    fn default() -> Self {
+        Self {
+            root: crate::empty_trie_hash!(),
+        }
+    }
+}
+pub fn insert_element<'a, F>(
+    collection: &'a TrieCollection<MapWithCounterCached>,
+    account_key: &[u8],
+    data_key: &[u8],
+    data: &[u8],
+    input_root: H256,
+    child_extractor: F,
+) -> RootGuard<'a, MapWithCounterCached, F>
+where
+    F: FnMut(&[u8]) -> Vec<H256> + Clone,
+{
+    // Insert to first db
+    let mut account_trie = collection.trie_for(input_root);
+    let mut account: DataWithRoot = TrieMut::get(&account_trie, account_key)
+        .map(|d| bincode::deserialize(&d).unwrap())
+        .unwrap_or_default();
+    let mut storage_trie = collection.trie_for(account.root);
+    storage_trie.insert(data_key, data);
+    let storage_patch = storage_trie.into_patch();
+    log::trace!(
+        "1 Update account root: old {}, new {}",
+        account.root,
+        storage_patch.root
+    );
+    account.root = storage_patch.root;
+    account_trie.insert(account_key, &bincode::serialize(&account).unwrap());
+    let mut account_patch = account_trie.into_patch();
+    account_patch.change.merge_child(&storage_patch.change);
+
+    collection.apply_increase(account_patch, child_extractor)
+}

--- a/src/ops/debug/mod.rs
+++ b/src/ops/debug/mod.rs
@@ -1,9 +1,17 @@
+use crate::cache::AsyncCachedHandle;
+use crate::gc::MapWithCounter;
+use std::sync::Arc;
+
 mod draw;
 
 #[cfg(test)]
 mod hex_input;
 
+pub mod child_extractor;
+
 pub use draw::{draw, Child, DebugPrintExt};
 
 #[cfg(test)]
 pub use hex_input::EntriesHex;
+
+pub type MapWithCounterCached = AsyncCachedHandle<Arc<MapWithCounter>>;

--- a/src/ops/diff/tests.rs
+++ b/src/ops/diff/tests.rs
@@ -5,6 +5,7 @@ use rlp::Rlp;
 use serde_json::json;
 
 use crate::debug::DebugPrintExt;
+use crate::debug::MapWithCounterCached;
 use crate::gc::DbCounter;
 use crate::gc::TrieCollection;
 use crate::merkle::MerkleNode;
@@ -37,7 +38,6 @@ fn no_childs(_: &[u8]) -> Vec<H256> {
 // ['a','b'] -> 'aa' -> ['a', 'b']
 // branch -> extension -> branch
 use super::Change;
-use crate::gc::testing::MapWithCounterCached;
 
 #[test]
 fn test_extension_replaced_by_branch_extension() {

--- a/src/rocksdb.rs
+++ b/src/rocksdb.rs
@@ -320,7 +320,7 @@ mod tests {
     use std::io::Write;
     use std::sync::Arc;
 
-    use crate::empty_trie_hash;
+    use crate::debug::child_extractor::DataWithRoot;
     use crate::gc::TrieCollection;
     use crate::merkle::MerkleNode;
     use hex_literal::hex;
@@ -329,11 +329,10 @@ mod tests {
     use rlp::Rlp;
     use rocksdb_lib::IteratorMode;
     use rocksdb_lib::{ColumnFamilyDescriptor, Options};
-    use serde::{Deserialize, Serialize};
     use tempfile::tempdir;
 
     use super::*;
-    use crate::gc::tests::{FixedData, Key};
+    use crate::gc::tests::{FixedData, FixedKey};
     use crate::gc::RootGuard;
     use crate::impls::tests::{Data, K};
     use crate::mutable::TrieMut;
@@ -520,8 +519,8 @@ mod tests {
 
     #[quickcheck]
     fn qc_handles_several_key_changes(
-        kvs_1: HashMap<Key, FixedData>,
-        kvs_2: HashMap<Key, FixedData>,
+        kvs_1: HashMap<FixedKey, FixedData>,
+        kvs_2: HashMap<FixedKey, FixedData>,
     ) -> TestResult {
         if kvs_1.is_empty() || kvs_2.is_empty() {
             return TestResult::discard();
@@ -601,35 +600,13 @@ mod tests {
         TestResult::passed()
     }
 
-    #[derive(Eq, PartialEq, Debug, Clone, Copy, Serialize, Deserialize)]
-    pub struct DataWithRoot {
-        pub root: H256,
-    }
-
-    impl DataWithRoot {
-        fn get_childs(data: &[u8]) -> Vec<H256> {
-            bincode::deserialize::<Self>(data)
-                .ok()
-                .into_iter()
-                .map(|e| e.root)
-                .collect()
-        }
-    }
-    impl Default for DataWithRoot {
-        fn default() -> Self {
-            Self {
-                root: empty_trie_hash!(),
-            }
-        }
-    }
-
     // todo implement data with child collection.
     #[quickcheck]
     fn qc_handles_inner_roots(
-        alice_key: Key,
-        alice_chages: Vec<(Key, FixedData)>,
-        bob_key: Key,
-        bob_storage: HashMap<Key, FixedData>,
+        alice_key: FixedKey,
+        alice_chages: Vec<(FixedKey, FixedData)>,
+        bob_key: FixedKey,
+        bob_storage: HashMap<FixedKey, FixedData>,
     ) -> TestResult {
         if alice_chages.is_empty() || bob_storage.is_empty() {
             return TestResult::discard();
@@ -905,159 +882,159 @@ mod tests {
         ];
         let changes1 = vec![
             (
-                Key([119, 0, 0, 3]),
+                FixedKey([119, 0, 0, 3]),
                 vec![
-                    (Key([11, 119, 0, 119]), FixedData(hex_1)),
-                    (Key([3, 51, 51, 183]), FixedData(hex_1)),
-                    (Key([0, 0, 255, 240]), FixedData(hex_1)),
-                    (Key([255, 255, 255, 255]), FixedData(hex_238)),
-                    (Key([255, 255, 255, 255]), FixedData(hex_238)),
-                    (Key([0, 0, 7, 55]), FixedData(hex_238)),
+                    (FixedKey([11, 119, 0, 119]), FixedData(hex_1)),
+                    (FixedKey([3, 51, 51, 183]), FixedData(hex_1)),
+                    (FixedKey([0, 0, 255, 240]), FixedData(hex_1)),
+                    (FixedKey([255, 255, 255, 255]), FixedData(hex_238)),
+                    (FixedKey([255, 255, 255, 255]), FixedData(hex_238)),
+                    (FixedKey([0, 0, 7, 55]), FixedData(hex_238)),
                 ],
             ),
             (
-                Key([112, 7, 119, 0]),
+                FixedKey([112, 7, 119, 0]),
                 vec![
-                    (Key([51, 51, 183, 112]), FixedData(hex_238)),
-                    (Key([0, 0, 0, 0]), FixedData(hex_238)),
-                    (Key([0, 0, 0, 48]), FixedData(hex_238)),
-                    (Key([112, 119, 0, 0]), FixedData(hex_238)),
-                    (Key([255, 255, 255, 255]), FixedData(hex_238)),
-                    (Key([255, 255, 240, 48]), FixedData(hex_238)),
-                    (Key([3, 112, 183, 112]), FixedData(hex_238)),
-                    (Key([119, 0, 51, 51]), FixedData(hex_238)),
+                    (FixedKey([51, 51, 183, 112]), FixedData(hex_238)),
+                    (FixedKey([0, 0, 0, 0]), FixedData(hex_238)),
+                    (FixedKey([0, 0, 0, 48]), FixedData(hex_238)),
+                    (FixedKey([112, 119, 0, 0]), FixedData(hex_238)),
+                    (FixedKey([255, 255, 255, 255]), FixedData(hex_238)),
+                    (FixedKey([255, 255, 240, 48]), FixedData(hex_238)),
+                    (FixedKey([3, 112, 183, 112]), FixedData(hex_238)),
+                    (FixedKey([119, 0, 51, 51]), FixedData(hex_238)),
                 ],
             ),
             (
-                Key([112, 0, 0, 0]),
+                FixedKey([112, 0, 0, 0]),
                 vec![
-                    (Key([0, 0, 0, 0]), FixedData(hex_238)),
-                    (Key([0, 0, 0, 0]), FixedData(hex_238)),
-                    (Key([0, 0, 0, 0]), FixedData(hex_238)),
-                    (Key([0, 0, 240, 0]), FixedData(hex_238)),
-                    (Key([0, 0, 11, 119]), FixedData(hex_238)),
-                    (Key([0, 48, 0, 0]), FixedData(hex_1)),
+                    (FixedKey([0, 0, 0, 0]), FixedData(hex_238)),
+                    (FixedKey([0, 0, 0, 0]), FixedData(hex_238)),
+                    (FixedKey([0, 0, 0, 0]), FixedData(hex_238)),
+                    (FixedKey([0, 0, 240, 0]), FixedData(hex_238)),
+                    (FixedKey([0, 0, 11, 119]), FixedData(hex_238)),
+                    (FixedKey([0, 48, 0, 0]), FixedData(hex_1)),
                 ],
             ),
             (
-                Key([0, 0, 55, 11]),
+                FixedKey([0, 0, 55, 11]),
                 vec![
-                    (Key([112, 7, 119, 0]), FixedData(hex_238)),
-                    (Key([0, 0, 3, 0]), FixedData(hex_238)),
-                    (Key([7, 112, 0, 0]), FixedData(hex_238)),
-                    (Key([255, 255, 255, 255]), FixedData(hex_238)),
-                    (Key([255, 255, 3, 0]), FixedData(hex_238)),
-                    (Key([55, 11, 119, 0]), FixedData(hex_1)),
-                    (Key([112, 3, 51, 51]), FixedData(hex_0)),
-                    (Key([112, 0, 0, 0]), FixedData(hex_238)),
-                    (Key([0, 0, 0, 0]), FixedData(hex_238)),
-                    (Key([0, 0, 0, 0]), FixedData(hex_238)),
-                    (Key([0, 15, 0, 0]), FixedData(hex_238)),
-                    (Key([0, 0, 183, 112]), FixedData(hex_238)),
-                    (Key([3, 0, 0, 3]), FixedData(hex_255)),
-                    (Key([0, 0, 0, 7]), FixedData(hex_1)),
-                    (Key([11, 119, 7, 15]), FixedData(hex_0)),
+                    (FixedKey([112, 7, 119, 0]), FixedData(hex_238)),
+                    (FixedKey([0, 0, 3, 0]), FixedData(hex_238)),
+                    (FixedKey([7, 112, 0, 0]), FixedData(hex_238)),
+                    (FixedKey([255, 255, 255, 255]), FixedData(hex_238)),
+                    (FixedKey([255, 255, 3, 0]), FixedData(hex_238)),
+                    (FixedKey([55, 11, 119, 0]), FixedData(hex_1)),
+                    (FixedKey([112, 3, 51, 51]), FixedData(hex_0)),
+                    (FixedKey([112, 0, 0, 0]), FixedData(hex_238)),
+                    (FixedKey([0, 0, 0, 0]), FixedData(hex_238)),
+                    (FixedKey([0, 0, 0, 0]), FixedData(hex_238)),
+                    (FixedKey([0, 15, 0, 0]), FixedData(hex_238)),
+                    (FixedKey([0, 0, 183, 112]), FixedData(hex_238)),
+                    (FixedKey([3, 0, 0, 3]), FixedData(hex_255)),
+                    (FixedKey([0, 0, 0, 7]), FixedData(hex_1)),
+                    (FixedKey([11, 119, 7, 15]), FixedData(hex_0)),
                 ],
             ),
             (
-                Key([112, 0, 0, 0]),
+                FixedKey([112, 0, 0, 0]),
                 vec![
-                    (Key([112, 119, 0, 0]), FixedData(hex_238)),
-                    (Key([0, 0, 0, 0]), FixedData(hex_238)),
-                    (Key([0, 0, 48, 0]), FixedData(hex_238)),
-                    (Key([7, 112, 0, 0]), FixedData(hex_238)),
-                    (Key([7, 7, 0, 7]), FixedData(hex_1)),
-                    (Key([119, 119, 247, 176]), FixedData(hex_238)),
-                    (Key([0, 0, 0, 0]), FixedData(hex_1)),
-                    (Key([0, 0, 0, 0]), FixedData(hex_238)),
-                    (Key([0, 0, 0, 0]), FixedData(hex_238)),
+                    (FixedKey([112, 119, 0, 0]), FixedData(hex_238)),
+                    (FixedKey([0, 0, 0, 0]), FixedData(hex_238)),
+                    (FixedKey([0, 0, 48, 0]), FixedData(hex_238)),
+                    (FixedKey([7, 112, 0, 0]), FixedData(hex_238)),
+                    (FixedKey([7, 7, 0, 7]), FixedData(hex_1)),
+                    (FixedKey([119, 119, 247, 176]), FixedData(hex_238)),
+                    (FixedKey([0, 0, 0, 0]), FixedData(hex_1)),
+                    (FixedKey([0, 0, 0, 0]), FixedData(hex_238)),
+                    (FixedKey([0, 0, 0, 0]), FixedData(hex_238)),
                 ],
             ),
         ];
         let changes2 = vec![
             (
-                Key([15, 0, 0, 0]),
+                FixedKey([15, 0, 0, 0]),
                 vec![
-                    (Key([0, 11, 119, 0]), FixedData(hex_238)),
-                    (Key([48, 0, 0, 48]), FixedData(hex_238)),
-                    (Key([0, 3, 112, 183]), FixedData(hex_1)),
-                    (Key([15, 187, 0, 0]), FixedData(hex_255)),
-                    (Key([0, 3, 0, 7]), FixedData(hex_238)),
-                    (Key([112, 0, 0, 255]), FixedData(hex_238)),
-                    (Key([255, 255, 255, 255]), FixedData(hex_238)),
-                    (Key([255, 3, 0, 0]), FixedData(hex_1)),
-                    (Key([11, 119, 0, 119]), FixedData(hex_1)),
-                    (Key([3, 51, 51, 183]), FixedData(hex_1)),
-                    (Key([0, 0, 0, 0]), FixedData(hex_238)),
-                    (Key([0, 0, 0, 0]), FixedData(hex_238)),
-                    (Key([0, 0, 0, 0]), FixedData(hex_238)),
-                    (Key([15, 0, 0, 0]), FixedData(hex_238)),
-                    (Key([0, 183, 112, 0]), FixedData(hex_238)),
+                    (FixedKey([0, 11, 119, 0]), FixedData(hex_238)),
+                    (FixedKey([48, 0, 0, 48]), FixedData(hex_238)),
+                    (FixedKey([0, 3, 112, 183]), FixedData(hex_1)),
+                    (FixedKey([15, 187, 0, 0]), FixedData(hex_255)),
+                    (FixedKey([0, 3, 0, 7]), FixedData(hex_238)),
+                    (FixedKey([112, 0, 0, 255]), FixedData(hex_238)),
+                    (FixedKey([255, 255, 255, 255]), FixedData(hex_238)),
+                    (FixedKey([255, 3, 0, 0]), FixedData(hex_1)),
+                    (FixedKey([11, 119, 0, 119]), FixedData(hex_1)),
+                    (FixedKey([3, 51, 51, 183]), FixedData(hex_1)),
+                    (FixedKey([0, 0, 0, 0]), FixedData(hex_238)),
+                    (FixedKey([0, 0, 0, 0]), FixedData(hex_238)),
+                    (FixedKey([0, 0, 0, 0]), FixedData(hex_238)),
+                    (FixedKey([15, 0, 0, 0]), FixedData(hex_238)),
+                    (FixedKey([0, 183, 112, 0]), FixedData(hex_238)),
                 ],
             ),
             (
-                Key([0, 0, 48, 0]),
+                FixedKey([0, 0, 48, 0]),
                 vec![
-                    (Key([0, 0, 7, 0]), FixedData(hex_238)),
-                    (Key([112, 119, 119, 247]), FixedData(hex_0)),
-                    (Key([0, 0, 0, 0]), FixedData(hex_238)),
-                    (Key([0, 0, 0, 0]), FixedData(hex_238)),
-                    (Key([0, 0, 0, 0]), FixedData(hex_238)),
-                    (Key([123, 176, 15, 0]), FixedData(hex_238)),
-                    (Key([0, 0, 0, 183]), FixedData(hex_1)),
-                    (Key([0, 3, 0, 0]), FixedData(hex_238)),
-                    (Key([0, 0, 0, 55]), FixedData(hex_238)),
+                    (FixedKey([0, 0, 7, 0]), FixedData(hex_238)),
+                    (FixedKey([112, 119, 119, 247]), FixedData(hex_0)),
+                    (FixedKey([0, 0, 0, 0]), FixedData(hex_238)),
+                    (FixedKey([0, 0, 0, 0]), FixedData(hex_238)),
+                    (FixedKey([0, 0, 0, 0]), FixedData(hex_238)),
+                    (FixedKey([123, 176, 15, 0]), FixedData(hex_238)),
+                    (FixedKey([0, 0, 0, 183]), FixedData(hex_1)),
+                    (FixedKey([0, 3, 0, 0]), FixedData(hex_238)),
+                    (FixedKey([0, 0, 0, 55]), FixedData(hex_238)),
                 ],
             ),
             (
-                Key([112, 7, 119, 0]),
+                FixedKey([112, 7, 119, 0]),
                 vec![
-                    (Key([0, 0, 0, 48]), FixedData(hex_238)),
-                    (Key([112, 119, 0, 0]), FixedData(hex_238)),
-                    (Key([255, 255, 255, 255]), FixedData(hex_238)),
-                    (Key([255, 255, 240, 48]), FixedData(hex_238)),
-                    (Key([3, 112, 183, 112]), FixedData(hex_238)),
-                    (Key([119, 0, 51, 51]), FixedData(hex_238)),
+                    (FixedKey([0, 0, 0, 48]), FixedData(hex_238)),
+                    (FixedKey([112, 119, 0, 0]), FixedData(hex_238)),
+                    (FixedKey([255, 255, 255, 255]), FixedData(hex_238)),
+                    (FixedKey([255, 255, 240, 48]), FixedData(hex_238)),
+                    (FixedKey([3, 112, 183, 112]), FixedData(hex_238)),
+                    (FixedKey([119, 0, 51, 51]), FixedData(hex_238)),
                 ],
             ),
             (
-                Key([112, 0, 0, 0]),
+                FixedKey([112, 0, 0, 0]),
                 vec![
-                    (Key([0, 0, 0, 0]), FixedData(hex_238)),
-                    (Key([0, 0, 0, 0]), FixedData(hex_238)),
-                    (Key([0, 0, 240, 0]), FixedData(hex_238)),
-                    (Key([0, 0, 11, 119]), FixedData(hex_238)),
-                    (Key([0, 48, 0, 0]), FixedData(hex_1)),
+                    (FixedKey([0, 0, 0, 0]), FixedData(hex_238)),
+                    (FixedKey([0, 0, 0, 0]), FixedData(hex_238)),
+                    (FixedKey([0, 0, 240, 0]), FixedData(hex_238)),
+                    (FixedKey([0, 0, 11, 119]), FixedData(hex_238)),
+                    (FixedKey([0, 48, 0, 0]), FixedData(hex_1)),
                 ],
             ),
             (
-                Key([0, 0, 0, 0]),
+                FixedKey([0, 0, 0, 0]),
                 vec![
-                    (Key([0, 0, 0, 0]), FixedData(hex_238)),
-                    (Key([0, 0, 0, 0]), FixedData(hex_238)),
-                    (Key([0, 0, 0, 0]), FixedData(hex_238)),
-                    (Key([0, 0, 0, 0]), FixedData(hex_238)),
-                    (Key([0, 0, 0, 0]), FixedData(hex_238)),
-                    (Key([0, 0, 0, 0]), FixedData(hex_238)),
-                    (Key([0, 0, 0, 0]), FixedData(hex_238)),
-                    (Key([119, 112, 183, 112]), FixedData(hex_1)),
-                    (Key([255, 240, 112, 0]), FixedData(hex_238)),
-                    (Key([0, 7, 7, 112]), FixedData(hex_238)),
-                    (Key([0, 0, 0, 0]), FixedData(hex_238)),
-                    (Key([0, 0, 0, 3]), FixedData(hex_238)),
-                    (Key([0, 0, 119, 0]), FixedData(hex_238)),
-                    (Key([0, 0, 119, 176]), FixedData(hex_238)),
-                    (Key([119, 7, 119, 183]), FixedData(hex_1)),
-                    (Key([0, 0, 0, 0]), FixedData(hex_238)),
-                    (Key([0, 0, 0, 3]), FixedData(hex_238)),
-                    (Key([0, 0, 11, 119]), FixedData(hex_238)),
-                    (Key([119, 112, 3, 51]), FixedData(hex_238)),
-                    (Key([183, 112, 0, 0]), FixedData(hex_0)),
+                    (FixedKey([0, 0, 0, 0]), FixedData(hex_238)),
+                    (FixedKey([0, 0, 0, 0]), FixedData(hex_238)),
+                    (FixedKey([0, 0, 0, 0]), FixedData(hex_238)),
+                    (FixedKey([0, 0, 0, 0]), FixedData(hex_238)),
+                    (FixedKey([0, 0, 0, 0]), FixedData(hex_238)),
+                    (FixedKey([0, 0, 0, 0]), FixedData(hex_238)),
+                    (FixedKey([0, 0, 0, 0]), FixedData(hex_238)),
+                    (FixedKey([119, 112, 183, 112]), FixedData(hex_1)),
+                    (FixedKey([255, 240, 112, 0]), FixedData(hex_238)),
+                    (FixedKey([0, 7, 7, 112]), FixedData(hex_238)),
+                    (FixedKey([0, 0, 0, 0]), FixedData(hex_238)),
+                    (FixedKey([0, 0, 0, 3]), FixedData(hex_238)),
+                    (FixedKey([0, 0, 119, 0]), FixedData(hex_238)),
+                    (FixedKey([0, 0, 119, 176]), FixedData(hex_238)),
+                    (FixedKey([119, 7, 119, 183]), FixedData(hex_1)),
+                    (FixedKey([0, 0, 0, 0]), FixedData(hex_238)),
+                    (FixedKey([0, 0, 0, 3]), FixedData(hex_238)),
+                    (FixedKey([0, 0, 11, 119]), FixedData(hex_238)),
+                    (FixedKey([119, 112, 3, 51]), FixedData(hex_238)),
+                    (FixedKey([183, 112, 0, 0]), FixedData(hex_0)),
                 ],
             ),
         ];
 
-        fn routine(db: std::sync::Arc<DB>, changes: Vec<(Key, Vec<(Key, FixedData)>)>) {
+        fn routine(db: std::sync::Arc<DB>, changes: Vec<(FixedKey, Vec<(FixedKey, FixedData)>)>) {
             let cf = db.cf_handle("counter").unwrap();
             let collection =
                 TrieCollection::new(RocksHandle::new(RocksDatabaseHandle::new(&*db, cf)));
@@ -1068,7 +1045,7 @@ mod tests {
                 DataWithRoot::get_childs,
             );
 
-            let mut accounts_map: HashMap<Key, HashMap<Key, FixedData>> = HashMap::new();
+            let mut accounts_map: HashMap<FixedKey, HashMap<FixedKey, FixedData>> = HashMap::new();
             {
                 for (k, storage) in changes.iter() {
                     let account_storage_mem =


### PR DESCRIPTION
- [x] (passes) quickcheck 1 - empty intersection of remove/inserts on all distinct values, fixed key len, no_childs 
- [x] (ignored, not implemented yet) quickcheck 2 - empty intersection of remove/inserts on all distinct values, var key len, no_childs
- [x] (passes) quickcheck 3 - patch reversable, empty intersection of remove/inserts on all distinct values, fixed key len, no_childs 
- [x] (ignored, not implemented yet) quickcheck 4 - patch reversable, empty intersection of remove/inserts on all distinct values, var key len, no_childs
- [ ] quickcheck 5 - empty intersection of remove/inserts on all distinct values, fixed key len, DataWithRoot
- [ ] quickcheck 6 - empty intersection of remove/inserts on all distinct values, var key len, DataWithRoot
- [ ] 1 fuzz - keys of var len, DataWithRoot 